### PR TITLE
RFC: fix insupport(X::Semicircle,x::Real) definition and calls

### DIFF
--- a/src/densities/Semicircle.jl
+++ b/src/densities/Semicircle.jl
@@ -20,13 +20,13 @@ Semicircle() = Semicircle(0.0, 2.0)
 # cumulative distribution function
 function cdf(X::Semicircle, x::Real)
     r, a = X.mean, X.radius
-    insupport(x) ? 0.5 + (x-a)/(pi*r^2) * sqrt(r^2 - (x-a)^2) + 1/pi * asin((x-a)/r) : (x>a ? 1.0 : 0.0)
+    insupport(X, x) ? 0.5 + (x-a)/(pi*r^2) * sqrt(r^2 - (x-a)^2) + 1/pi * asin((x-a)/r) : (x>a ? 1.0 : 0.0)
 end
 
 # probability density function
 function pdf(X::Semicircle, x::Real)
     r, a = X.mean, X.radius
-    insupport(x) ? 2/(pi*r^2) * sqrt(r^2 - (x-a)^2) : 0.0
+    insupport(X, x) ? 2/(pi*r^2) * sqrt(r^2 - (x-a)^2) : 0.0
 end
 
 # predicate is x in the support of the distribution?

--- a/src/densities/Semicircle.jl
+++ b/src/densities/Semicircle.jl
@@ -30,7 +30,7 @@ function pdf(X::Semicircle, x::Real)
 end
 
 # predicate is x in the support of the distribution?
-insupport(X::Semicircle, x::Real)=abs(x)<=X.radius
+insupport(X::Semicircle, x::Real)=abs(x-X.mean)<=X.radius
 
 
 #Entropy methods


### PR DESCRIPTION
This pull request corrects two errors in Semicircle.jl. First, the support of the semicircular distribution is centered at its mean, which might not be 0. (Not that I've ever used a semicircle distribution with nonzero mean...) Second, the calls to this function are missing the first argument.
