### PR TITLE
fix randomgrowth.jl

### DIFF
--- a/demos/book/8/randomgrowth.jl
+++ b/demos/book/8/randomgrowth.jl
@@ -12,7 +12,7 @@ function random_growth(M, N, q)
         sets = next_possible_squares(G)
         ## Highlights all the possible squares
         for i = 1:length(sets)
-            idx = sets[i]::(Int,Int)
+            idx = sets[i]
             G[idx[1], idx[2]] = 0.25
         end
         display(imagesc((0,N), (M,0), G))
@@ -22,21 +22,21 @@ function random_growth(M, N, q)
         for i = 1:length(sets)
             ison = 0.5 * (rand() > (1-q))
             if ison > 0
-                idx = sets[i]::(Int,Int)
+                idx = sets[i]
                 G[idx[1], idx[2]] = ison
             end
         end
         display(imagesc((0,N), (M,0), G))
-        G[G .== 0.5] = 1
-        G[G .== 0.25] = 0
+        G[findall(G .== 0.5)] .= 1
+        G[findall(G .== 0.25)] .= 0
         sleep(.01)
     end
     return G
 end
 
 function next_possible_squares(G)
-    M, N = size(G)::(Int,Int)
-    sets = Array((Int,Int),0)
+    M, N = size(G)
+    sets = Array{Tuple{Int,Int}, 1}(undef, 0)
     for ii = 1:M
         for jj = 1:N
             if G[ii, jj] == 0

--- a/demos/book/8/randomgrowth.jl
+++ b/demos/book/8/randomgrowth.jl
@@ -27,8 +27,8 @@ function random_growth(M, N, q)
             end
         end
         display(imagesc((0,N), (M,0), G))
-        G[findall(G .== 0.5)] .= 1
-        G[findall(G .== 0.25)] .= 0
+        G[findall(isequal(0.50), G)] .= 1
+        G[findall(isequal(0.25), G)] .= 0
         sleep(.01)
     end
     return G


### PR DESCRIPTION
This is a julia bug?

```julia
julia> G = rand(100,100);

julia> G[G .== 0.5] = 1
ERROR: MethodError: no method matching setindex_shape_check(::Int64, ::Int64)
Closest candidates are:
  setindex_shape_check(::AbstractArray{#s72,1} where #s72, ::Integer) at indices.jl:218
  setindex_shape_check(::AbstractArray{#s72,1} where #s72, ::Integer, ::Integer) at indices.jl:221
  setindex_shape_check(::AbstractArray{#s72,2} where #s72, ::Integer, ::Integer) at indices.jl:225
  ...
Stacktrace:
 [1] macro expansion at ./multidimensional.jl:694 [inlined]
 [2] _unsafe_setindex!(::IndexLinear, ::Array{Float64,2}, ::Int64, ::Base.LogicalIndex{Int64,BitArray{2}}) at ./multidimensional.jl:689
 [3] _setindex! at ./multidimensional.jl:684 [inlined]
 [4] setindex!(::Array{Float64,2}, ::Int64, ::BitArray{2}) at ./abstractarray.jl:1020
 [5] top-level scope at none:0

```

this patch includes a workaround.