### PR TITLE
Update FastGaussQuadrature compat to include 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Combinatorics = "0.7.0, 1"
 Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
-FastGaussQuadrature = "0.3, 0.4"
+FastGaussQuadrature = "0.3, 0.4, 0.5"
 GSL = "0.4, 1"
 SpecialFunctions = "0.7, 1, 2"
 julia = "0.7, 1"


### PR DESCRIPTION
Currently I cannot ClassicalOrthogonalPolynomials.jl together with this package as ClassicalOrthogonalPolynomials.jl has compat of only FastGaussQuadrature 0.5. The tests seem to pass for me with the latest FastGaussQuadrature.