### PR TITLE
Bumped compat for FastGaussQuadrature.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Combinatorics = "0.7.0, 1"
 Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
-FastGaussQuadrature = "0.3, 0.4, 0.5"
+FastGaussQuadrature = "0.3, 0.4, 0.5, 1"
 GSL = "0.4, 1"
 SpecialFunctions = "0.7, 1, 2"
 julia = "0.7, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RandomMatrices"
 uuid = "2576dda1-a324-5b11-aa66-c48ed7e3c618"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
I made sure that all tests still run and that none of the functions that got deprecated with the latest release of FastGaussQuadrature.jl are used here.

Creating this PR here because using the old version of FaustGaussQuadrature.jl lead to some weird precompilation errors that got fixed by bumping the compat here.