### PR TITLE
Fix `rand(d::GaussianLaguerre, n::Int)`, improve performance, add tests

### DIFF
--- a/test/GaussianEnsembles.jl
+++ b/test/GaussianEnsembles.jl
@@ -4,28 +4,52 @@ using Test
 @testset "GaussianEnsembles" begin
 
 @test Wigner{3} == GaussianHermite{3}
+@test Wishart == GaussianLaguerre
 
 n = 25
 
 for (β, T, N) in [(1, Real, n), (2, Complex, n), (4, Complex, 2n)]
-    d = Wigner(β)
-    A = rand(d, n)
-    @test eltype(A) <: T
-    @test size(A) == (N, N)
-    
-    At = tridrand(d, n)
-    @test eltype(At) <: Real
-    @test size(At) == (n, n)
+    @testset "Wigner (β = $(β))" begin
+        d = Wigner(β)
+        A = rand(d, n)
+        @test eltype(A) <: T
+        @test size(A) == (N, N)
+        
+        At = tridrand(d, n)
+        @test eltype(At) <: Real
+        @test size(At) == (n, n)
 
-    vals = eigvalrand(d, n)
-    @test eltype(vals) <: Real
-    @test length(vals) == n
+        vals = eigvalrand(d, n)
+        @test eltype(vals) <: Real
+        @test length(vals) == n
 
-    vd = RandomMatrices.VandermondeDeterminant(vals, β)
-    @test isa(vd, Real)
+        vd = RandomMatrices.VandermondeDeterminant(vals, β)
+        @test isa(vd, Real)
 
-    ed = eigvaljpdf(d, vals)
-    @test isa(ed, Real)
+        ed = eigvaljpdf(d, vals)
+        @test isa(ed, Real)
+    end
+    @testset "Wishart (β = $(β))" begin
+        a = 2(rand(1:5) + β * n)
+        d = Wishart(β, a)
+        A = rand(d, n)
+        @test eltype(A) <: T
+        @test size(A) == (N, N)
+        
+        @test_throws UndefVarError tridrand(d, n) # = At
+        #@test eltype(At) <: Real
+        #@test size(At) == (n, n)
+
+        @test_throws UndefVarError eigvalrand(d, n) # = vals
+        #@test eltype(vals) <: Real
+        #@test length(vals) == n
+
+        #vd = RandomMatrices.VandermondeDeterminant(vals, β)
+        #@test isa(vd, Real)
+
+        #ed = eigvaljpdf(d, vals)
+        #@test isa(ed, Real)
+    end
 end
 
 end # testset


### PR DESCRIPTION
Note that I replaced the method `rand(d::GaussianLaguerre, n::dims)` with `rand(d::GaussianLaguerre, n::Int)` to match similar `rand` methods for other random matrix ensembles in the package. Ping @dlfivefifty for review.